### PR TITLE
Avoid calling target in push-release

### DIFF
--- a/src/degree9/boot_semver.clj
+++ b/src/degree9/boot_semver.clj
@@ -110,7 +110,6 @@
   [f file PATH str "The jar file to deploy."]
   (comp
    (impl/version-clojars)
-   (task/target)
    (task/push
      :file           file
      :tag            (boolean (util/guard (git/last-commit)))


### PR DESCRIPTION
Calling it was wiping the existing target folder therefore not allowing
push-release to be called in isolation.
It also makes sense, for consistency with push-snapshot, to let upstream call
the target task.